### PR TITLE
Fix HTTPS mixed content errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+url: https://azubkov.com
 markdown: kramdown
 paginate: 15
 gems:


### PR DESCRIPTION
## Problem
The site loads over HTTPS but all CSS/JS resources are loaded via HTTP, causing mixed content errors and broken styling.

## Root Cause
No `url` was set in `_config.yml`, so Jekyll defaults to `http://azubkov.com`. All `{{ site.url }}` references in templates resolve to HTTP.

## Fix
Added `url: https://azubkov.com` to `_config.yml`. One line change.

## Impact
All resource URLs (`site.url` references) will now use HTTPS — CSS, JS, images, canonical links, etc.